### PR TITLE
Merge Develop to Main

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,7 +6,7 @@ const nextConfig: NextConfig = {
     reactCompiler: true,
     serverActions: {
       bodySizeLimit: '20MB',
-      allowedOrigins: ['gsmc.io.kr', 'www.gsmc.io.kr', 'gsmc-client-v3.vercel.app'],
+      allowedOrigins: process.env.ALLOWED_ORIGINS?.split(',') ?? [],
     },
     middlewareClientMaxBodySize: '20MB',
   },


### PR DESCRIPTION
## #️⃣연관된 이슈



## 📝작업 내용
> 2025-12-24 05:59:20.757 [error] `x-forwarded-host` header with value `gsmc-client-v3.vercel.app` does not match `origin` header with value `gsmc.io.kr` from a forwarded Server Actions request. Aborting the action.
2025-12-24 05:59:20.761 [error] [Error: Invalid Server Actions request.] { digest: '3903312758' }

header의 origin이 일치하지 않아서 server action이 실행되지 않고 에러를 뱉는 오류를 수정하였습닌다.


### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)
어드민 페이지에도 적용되어야 합니다.
