### PR TITLE
fix: 릴리즈 Draft가 두번 생성되는 문제

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,9 +1,6 @@
 name: Release Drafter
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     types: [closed]
     branches:
@@ -16,7 +13,7 @@ permissions:
 
 jobs:
   update_release_draft:
-    if: github.event.pull_request.merged == true || github.event_name == 'push'
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## #️⃣연관된 이슈


## 📝작업 내용
- push, pr merge 시 릴리즈 Draft가 생성 되어 총 2개의 Draft가 생성되던 문제를 해결하였습니다.


### 스크린샷 (선택)


## 💬리뷰 요구사항(선택)